### PR TITLE
Remove NODE_OPTIONS flag from workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           node-version: '16.x'
       - name: Install modules
-        run: export NODE_OPTIONS=--openssl-legacy-provider && yarn
+        run: yarn
       - name: Build
-        run: export NODE_OPTIONS=--openssl-legacy-provider && yarn build
+        run: yarn build
       - name: Deploy
         uses: crazy-max/ghaction-github-pages@v1
         with:


### PR DESCRIPTION
## Summary
Removes the `--openssl-legacy-provider` flag from NODE_OPTIONS as it's no longer allowed by Node.js and is not needed with Node 16.x.

## Changes
- Removed `export NODE_OPTIONS=--openssl-legacy-provider &&` from install step
- Removed `export NODE_OPTIONS=--openssl-legacy-provider &&` from build step

## Why this fixes the issue
The previous fix added Node 16.x, but the workflow was still failing because:
> `node: --openssl-legacy-provider is not allowed in NODE_OPTIONS`

With Node 16.x, the OpenSSL legacy provider flag is not needed, and Node.js no longer permits it in the NODE_OPTIONS environment variable for security reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)